### PR TITLE
Add erlang 19.0

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -10,6 +10,7 @@ versions_list=(
   18.1
   18.2.1
   18.3
+  19.0
 )
 
 versions=""


### PR DESCRIPTION
http://www.erlang.org/news/105

Erlang 19.0 is out, so let's add it to the list.
