### PR TITLE
Add erlang 19.0.3

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -11,6 +11,7 @@ versions_list=(
   18.2.1
   18.3
   19.0
+  19.0.3
 )
 
 versions=""


### PR DESCRIPTION
Erlang [19.0.3](https://github.com/erlang/otp/releases/tag/OTP-19.0.3) contains some important bug fixes. For example – https://bugs.erlang.org/browse/ERL-190 (was fixed in 19.0.2).