### PR TITLE
Set GREP_OPTIONS to empty string before compiling Erlang.

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -17,6 +17,10 @@ install_erlang() {
   # running this in a subshell
   # because we don't want to disturb current working dir
   (
+    # GREP_OPTIONS must not set
+    # http://erlang.org/pipermail/erlang-questions/2014-April/078526.html
+    GREP_OPTIONS=""
+
     cd $(dirname $source_path)
     tar zxf $source_path || exit 1
     cd $(untar_path $install_type $version $tmp_download_dir)


### PR DESCRIPTION
This may be out of scope for asdf, I'm not sure if we want to be handling environmental stuff like this, but builds for me fail on both Ubuntu 14.04 and OSX 10.10 with my `GREP_OTIONS` set to `--color=always` in my `.bashrc`. Setting GREP_OPTIONS to an empty string ensures grep will  behave as expected.

This was also added to kerl - https://github.com/kerl/kerl/pull/99