### PR TITLE
Update libwxgtk version for Linux instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ When installing Erlang using `asdf install`, you can pass custom configure optio
 
 ## Before `asdf install`
 
+These steps assume a most recent build of Debian or Ubuntu Linux (currently
+tested on Ubuntu 16.04 LTS, "Xenial Xerus"). Note that if you are using a
+previous version of Linux, you may need a different version of one of the below
+libraries.
+
 Install the build tools (dpkg-dev g++ gcc libc6-dev make)  
 `apt-get -y install build-essential`
 
@@ -34,7 +39,7 @@ Needed for terminal handling (libc-dev libncurses5 libtinfo-dev libtinfo5 ncurse
 `apt-get -y install libncurses5-dev`
 
 For building with wxWidgets (start observer or debugger!)  
-+ **Linux**: `apt-get -y install libwxgtk2.8-dev libgl1-mesa-dev libglu1-mesa-dev libpng3`
++ **Linux**: `apt-get -y install libwxgtk3.0-dev libgl1-mesa-dev libglu1-mesa-dev libpng3`
 + **OS X**: `brew install wxmac`
 
 For building ssl (libssh-4 libssl-dev zlib1g-dev)  


### PR DESCRIPTION
Update libwxgtk version from 2.8 to 3.0 for Linux install instructions. Previous
command was returning `E: Unable to locate package libwxgtk2.8-dev`.

This was tested on a base Ubuntu install of 16.04.