### PR TITLE
Add FreeBSD support

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -34,11 +34,12 @@ install_erlang() {
     # set in os_based_configure_options
     # we unset it here because echo-ing changes the return value of the function
     unset ASDF_PKG_MISSING
+    local make="$(os_based_make_binary)"
 
     echo "Building with options: $configure_options"
     ./configure $configure_options || exit 1
-    make -j$ASDF_CONCURRENCY || exit 1
-    make install || exit 1
+    $make -j$ASDF_CONCURRENCY || exit 1
+    $make install || exit 1
 
     # I don't know how to install docs for tags
     if [ "$install_type" = "version" ]; then
@@ -84,6 +85,16 @@ homebrew_package_path() {
     echo ""
   else
     echo "$(brew --prefix $package_name 2> /dev/null)"
+  fi
+}
+
+
+os_based_make_binary() {
+  local operating_system=$(uname -a)
+  if [[ "$operating_system" =~ "FreeBSD" ]]; then
+    echo "gmake"
+  else
+    echo "make"
   fi
 }
 


### PR DESCRIPTION
Compiling Erlang on FreeBSD requires using `gmake` instead FreeBSD `make`.