### PR TITLE
update to `tar xvf` and path release in github

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -22,7 +22,7 @@ install_erlang() {
     GREP_OPTIONS=""
 
     cd $(dirname $source_path)
-    tar zxf $source_path || exit 1
+    tar xvf $source_path || exit 1
     cd $(untar_path $install_type $version $tmp_download_dir)
 
     if [ "$install_type" != "version" ]
@@ -49,7 +49,7 @@ install_erlang() {
             download_docs $version $source_path
 
             cd $(dirname $source_path)
-            tar -xzvf $source_path || exit 1
+            tar xvf $source_path || exit 1
 
             # Place the `man` directory in the Erlang install
             mv man $install_path/lib/erlang/
@@ -131,7 +131,7 @@ untar_path() {
   then
     echo "$tmp_download_dir/otp_src_${version}"
   else
-    echo "$tmp_download_dir/otp-${version}"
+    echo "$tmp_download_dir/otp-OTP-${version}"
   fi
 }
 
@@ -182,7 +182,7 @@ get_download_url() {
   then
     echo "http://www.erlang.org/download/otp_src_${version}.tar.gz"
   else
-    echo "https://github.com/erlang/otp/archive/${version}.tar.gz"
+    echo "https://github.com/erlang/otp/archive/OTP-${version}.tar.gz"
   fi
 }
 


### PR DESCRIPTION
**1. I tried to run, there was an error message**
https://github.com/asdf-vm/asdf-erlang/blob/9aa8a6d5a1553ad7c8b770e4af0f09a0a67ab8d5/bin/install#L25
https://github.com/asdf-vm/asdf-erlang/blob/9aa8a6d5a1553ad7c8b770e4af0f09a0a67ab8d5/bin/install#L52
```
gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```

**2. The release in github is incorrect**
https://github.com/asdf-vm/asdf-erlang/blob/9aa8a6d5a1553ad7c8b770e4af0f09a0a67ab8d5/bin/install#L185