### PR TITLE
Add version 20.1

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -15,6 +15,7 @@ versions_list=(
   19.2
   19.3
   20.0
+  20.1
 )
 
 versions=""


### PR DESCRIPTION
OTP 20.1 has been released, `asdf install erlang 20.1` worked for me on my High Sierra mac :-)

http://www.erlang.org/news/115