### PR TITLE
Add 20.2 to versions list

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -16,6 +16,7 @@ versions_list=(
   19.3
   20.0
   20.1
+  20.2
 )
 
 versions=""


### PR DESCRIPTION
This PR adds erlang version 20.2 to the versions list: https://github.com/erlang/otp/releases/tag/OTP-20.2