### PR TITLE
Use kerl for managing Erlang versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # asdf-erlang
 
-Erlang plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
+Erlang plugin for [asdf](https://github.com/asdf-vm/asdf) version manager that relies on [kerl](https://github.com/kerl/kerl) for builds.
+
+This plugin aims to combine the best of both worlds by using kerl.
+
+kerl's compatibility and build scripts, together with asdf's easy version switching and support for the .tool-versions file. You do not need to have kerl already installed to use this. The plugin will install it's own version of kerl automatically.
 
 ## Install
 
@@ -10,14 +14,7 @@ asdf plugin-add erlang https://github.com/asdf-vm/asdf-erlang.git
 
 ## Use
 
-Check [asdf](https://github.com/asdf-vm/asdf) readme for instructions on how to install & manage versions of Erlang.
-
-When installing Erlang using `asdf install`, you can pass custom configure options with the following env vars:
-
-* `ERLANG_CONFIGURE_OPTIONS` - use only your configure options
-* `ERLANG_EXTRA_CONFIGURE_OPTIONS` - append these configure options along with ones that this plugin already uses
-* `ASDF_ERLANG_OPTIONS` - options for asdf-erlang itself. Available options:
-    * `no-docs` - don't download and install the man pages
+Check [asdf](https://github.com/asdf-vm/asdf) readme for instructions on how to install & manage versions of Erlang. See [kerl](https://github.com/kerl/kerl) for customization options. Note that the `KERL_BASE_DIR` and `KERL_CONFIG` environment variables are set by the plugin when it runs kerl so it will not be possible to customize them.
 
 ## Before `asdf install`
 

--- a/bin/install
+++ b/bin/install
@@ -1,72 +1,103 @@
 #!/usr/bin/env bash
 
+set -e
+
+source "$(dirname $0)/utils.sh"
+
 install_erlang() {
-  local install_type=$1
-  local version=$2
-  local install_path=$3
+  update_available_versions
 
-  if [ "$TMPDIR" = "" ]; then
-    local tmp_download_dir=$(mktemp -d -t erlang_build_XXXXXX)
-  else
-    local tmp_download_dir=$TMPDIR
-  fi
+  export MAKEFLAGS="-j$ASDF_CONCURRENCY"
+  $(kerl_path) build "$ASDF_INSTALL_VERSION" "asdf_$ASDF_INSTALL_VERSION"
+  $(kerl_path) install "asdf_$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"
+  $(kerl_path) cleanup "$ASDF_INSTALL_VERSION"
 
-  local source_path=$(get_download_file_path $install_type $version $tmp_download_dir)
-  download_source $install_type $version $source_path || return 1
+  link_app_executables $ASDF_INSTALL_PATH
+  echo
+  echo "Erlang $ASDF_INSTALL_VERSION has been installed. Activate globally with:"
+  echo
+  echo "    asdf global erlang $ASDF_INSTALL_VERSION"
+  echo
+  echo "Activate locally in the current folder with:"
+  echo
+  echo "    asdf local erlang $ASDF_INSTALL_VERSION"
+  echo
+}
 
-  # running this in a subshell
-  # because we don't want to disturb current working dir
-  (
-    # GREP_OPTIONS must not set
-    # http://erlang.org/pipermail/erlang-questions/2014-April/078526.html
-    GREP_OPTIONS=""
+install_erlang
 
-    cd $(dirname $source_path)
-    tar zxf $source_path || exit 1
-    cd $(untar_path $install_type $version $tmp_download_dir)
+#install_erlang() {
+#  local install_type=$1
+#  local version=$2
+#  local install_path=$3
+#
+#  if [ "$TMPDIR" = "" ]; then
+#    local tmp_download_dir=$(mktemp -d -t erlang_build_XXXXXX)
+#  else
+#    local tmp_download_dir=$TMPDIR
+#  fi
+#
+#  local source_path=$(get_download_file_path $install_type $version $tmp_download_dir)
+#  download_source $install_type $version $source_path || return 1
+#
+#  # running this in a subshell
+#  # because we don't want to disturb current working dir
+#  (
+#    # GREP_OPTIONS must not set
+#    # http://erlang.org/pipermail/erlang-questions/2014-April/078526.html
+#    GREP_OPTIONS=""
+#
+#    cd $(dirname $source_path)
+#    tar zxf $source_path || exit 1
+#    cd $(untar_path $install_type $version $tmp_download_dir)
+#
+#    if [ "$install_type" != "version" ]
+#    then
+#      ./otp_build autoconf || exit 1
+#    fi
+#
+#    local configure_options="$(construct_configure_options)"
+#    # set in os_based_configure_options
+#    # we unset it here because echo-ing changes the return value of the function
+#    unset ASDF_PKG_MISSING
+#    local make="$(os_based_make_binary)"
+#
+#    echo "Building with options: $configure_options"
+#    ./configure $configure_options || exit 1
+#    $make -j$ASDF_CONCURRENCY || exit 1
+#    $make install || exit 1
+#
+#    # I don't know how to install docs for tags
+#    if [ "$install_type" = "version" ]; then
+#        if install_man_pages; then
+#            echo "Downloading man pages"
+#            local source_path=$(get_docs_download_file_path $version $tmp_download_dir)
+#            download_docs $version $source_path
+#
+#            cd $(dirname $source_path)
+#            tar -xzvf $source_path || exit 1
+#
+#            # Place the `man` directory in the Erlang install
+#            mv man $install_path/lib/erlang/
+#        else
+#            echo "Skipping install of man pages"
+#        fi
+#    else
+#        echo "Skipping install of man pages"
+#    fi
+#    
+#    link_app_executables $install_path
+#  )
+#}
 
-    if [ "$install_type" != "version" ]
-    then
-      ./otp_build autoconf || exit 1
-    fi
+link_app_executables() {
+    local install_path=$1
 
-    local configure_options="$(construct_configure_options)"
-    # set in os_based_configure_options
-    # we unset it here because echo-ing changes the return value of the function
-    unset ASDF_PKG_MISSING
-    local make="$(os_based_make_binary)"
-
-    echo "Building with options: $configure_options"
-    ./configure $configure_options || exit 1
-    $make -j$ASDF_CONCURRENCY || exit 1
-    $make install || exit 1
-
-    # I don't know how to install docs for tags
-    if [ "$install_type" = "version" ]; then
-        if install_man_pages; then
-            echo "Downloading man pages"
-            local source_path=$(get_docs_download_file_path $version $tmp_download_dir)
-            download_docs $version $source_path
-
-            cd $(dirname $source_path)
-            tar -xzvf $source_path || exit 1
-
-            # Place the `man` directory in the Erlang install
-            mv man $install_path/lib/erlang/
-        else
-            echo "Skipping install of man pages"
-        fi
-    else
-        echo "Skipping install of man pages"
-    fi
-    
     # Link other executables to the bin directory so that asdf shims are created for them
     cd "$install_path/bin"
     ln -s ../lib/erlang/lib/*/priv/bin/* .
     ln -s ../lib/erlang/lib/*/bin/* .
-  )
 }
-
 
 construct_configure_options() {
   if [ "$ERLANG_CONFIGURE_OPTIONS" = "" ]; then
@@ -220,4 +251,4 @@ install_man_pages() {
 }
 
 
-install_erlang $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH
+#install_erlang $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH

--- a/bin/install
+++ b/bin/install
@@ -39,8 +39,7 @@ link_app_executables() {
 
     # Link other executables to the bin directory so that asdf shims are created for them
     cd "$install_path/bin"
-    ln -s ../lib/erlang/lib/*/priv/bin/* .
-    ln -s ../lib/erlang/lib/*/bin/* .
+    ln -s ../lib/*/bin/* ../lib/*/priv/bin/* .
 }
 
 download_docs() {

--- a/bin/install
+++ b/bin/install
@@ -35,8 +35,6 @@ install_erlang() {
   link_app_executables $ASDF_INSTALL_PATH
 }
 
-install_erlang
-
 link_app_executables() {
     local install_path=$1
 
@@ -90,3 +88,5 @@ install_man_pages() {
 
     return 0
 }
+
+install_erlang

--- a/bin/install
+++ b/bin/install
@@ -5,8 +5,7 @@ set -e
 source "$(dirname $0)/utils.sh"
 
 install_erlang() {
-  ensure_kerl_installed
-  update_available_versions
+  ensure_kerl_setup
 
   export MAKEFLAGS="-j$ASDF_CONCURRENCY"
   $(kerl_path) build "$ASDF_INSTALL_VERSION" "asdf_$ASDF_INSTALL_VERSION"

--- a/bin/install
+++ b/bin/install
@@ -5,6 +5,7 @@ set -e
 source "$(dirname $0)/utils.sh"
 
 install_erlang() {
+  ensure_kerl_installed
   update_available_versions
 
   export MAKEFLAGS="-j$ASDF_CONCURRENCY"
@@ -12,61 +13,6 @@ install_erlang() {
   $(kerl_path) install "asdf_$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"
   $(kerl_path) cleanup "$ASDF_INSTALL_VERSION"
 
-  link_app_executables $ASDF_INSTALL_PATH
-  echo
-  echo "Erlang $ASDF_INSTALL_VERSION has been installed. Activate globally with:"
-  echo
-  echo "    asdf global erlang $ASDF_INSTALL_VERSION"
-  echo
-  echo "Activate locally in the current folder with:"
-  echo
-  echo "    asdf local erlang $ASDF_INSTALL_VERSION"
-  echo
-}
-
-install_erlang
-
-#install_erlang() {
-#  local install_type=$1
-#  local version=$2
-#  local install_path=$3
-#
-#  if [ "$TMPDIR" = "" ]; then
-#    local tmp_download_dir=$(mktemp -d -t erlang_build_XXXXXX)
-#  else
-#    local tmp_download_dir=$TMPDIR
-#  fi
-#
-#  local source_path=$(get_download_file_path $install_type $version $tmp_download_dir)
-#  download_source $install_type $version $source_path || return 1
-#
-#  # running this in a subshell
-#  # because we don't want to disturb current working dir
-#  (
-#    # GREP_OPTIONS must not set
-#    # http://erlang.org/pipermail/erlang-questions/2014-April/078526.html
-#    GREP_OPTIONS=""
-#
-#    cd $(dirname $source_path)
-#    tar zxf $source_path || exit 1
-#    cd $(untar_path $install_type $version $tmp_download_dir)
-#
-#    if [ "$install_type" != "version" ]
-#    then
-#      ./otp_build autoconf || exit 1
-#    fi
-#
-#    local configure_options="$(construct_configure_options)"
-#    # set in os_based_configure_options
-#    # we unset it here because echo-ing changes the return value of the function
-#    unset ASDF_PKG_MISSING
-#    local make="$(os_based_make_binary)"
-#
-#    echo "Building with options: $configure_options"
-#    ./configure $configure_options || exit 1
-#    $make -j$ASDF_CONCURRENCY || exit 1
-#    $make install || exit 1
-#
 #    # I don't know how to install docs for tags
 #    if [ "$install_type" = "version" ]; then
 #        if install_man_pages; then
@@ -85,10 +31,11 @@ install_erlang
 #    else
 #        echo "Skipping install of man pages"
 #    fi
-#    
-#    link_app_executables $install_path
-#  )
-#}
+
+  link_app_executables $ASDF_INSTALL_PATH
+}
+
+install_erlang
 
 link_app_executables() {
     local install_path=$1
@@ -99,89 +46,6 @@ link_app_executables() {
     ln -s ../lib/erlang/lib/*/bin/* .
 }
 
-construct_configure_options() {
-  if [ "$ERLANG_CONFIGURE_OPTIONS" = "" ]; then
-    local configure_options="$(os_based_configure_options) --prefix=$install_path"
-
-    if [ "$ERLANG_EXTRA_CONFIGURE_OPTIONS" != "" ]; then
-      configure_options="$configure_options $ERLANG_EXTRA_CONFIGURE_OPTIONS"
-    fi
-  else
-    local configure_options="$ERLANG_CONFIGURE_OPTIONS --prefix=$install_path"
-  fi
-
-  echo "$configure_options"
-}
-
-
-homebrew_package_path() {
-  local package_name=$1
-
-  if [ "$(brew ls --versions $package_name 2> /dev/null)" = "" ]; then
-    echo ""
-  else
-    echo "$(brew --prefix $package_name 2> /dev/null)"
-  fi
-}
-
-
-os_based_make_binary() {
-  local operating_system=$(uname -a)
-  if [[ "$operating_system" =~ "FreeBSD" ]]; then
-    echo "gmake"
-  else
-    echo "make"
-  fi
-}
-
-
-os_based_configure_options() {
-  local operating_system=$(uname -a)
-  local configure_options=""
-
-  if [ "$ERLANG_OPENSSL_PATH" != "" ]; then
-      local openssl_path="$ERLANG_OPENSSL_PATH"
-  elif [[ "$operating_system" =~ "Darwin" ]]; then
-      local homebrew_openssl_path=$(homebrew_package_path openssl)
-      local openssl_path=${homebrew_openssl_path:-/usr}
-  else
-    local openssl_path=/usr
-  fi
-
-  if [ "$openssl_path" = "" ]; then
-    export ASDF_PKG_MISSING="openssl"
-  else
-    configure_options="$configure_options --with-ssl=$openssl_path"
-  fi
-
-  echo $configure_options
-}
-
-
-untar_path() {
-  local install_type=$1
-  local version=$2
-  local tmp_download_dir=$3
-
-  if [ "$install_type" = "version" ]
-  then
-    echo "$tmp_download_dir/otp_src_${version}"
-  else
-    echo "$tmp_download_dir/otp-${version}"
-  fi
-}
-
-
-download_source() {
-  local install_type=$1
-  local version=$2
-  local download_path=$3
-  local download_url=$(get_download_url $install_type $version)
-
-  curl -Lo $download_path -C - $download_url
-}
-
-
 download_docs() {
   local version=$1
   local download_path=$2
@@ -191,35 +55,12 @@ download_docs() {
 }
 
 
-get_download_file_path() {
-  local install_type=$1
-  local version=$2
-  local tmp_download_dir=$3
-  local pkg_name="otp-${install_type}-${version}-src.tar.gz"
-
-  echo "$tmp_download_dir/$pkg_name"
-}
-
-
 get_docs_download_file_path() {
   local version=$1
   local tmp_download_dir=$2
   local pkg_name="otp_doc_man_${version}.tar.gz"
 
   echo "$tmp_download_dir/$pkg_name"
-}
-
-
-get_download_url() {
-  local install_type=$1
-  local version=$2
-
-  if [ "$install_type" = "version" ]
-  then
-    echo "http://www.erlang.org/download/otp_src_${version}.tar.gz"
-  else
-    echo "https://github.com/erlang/otp/archive/${version}.tar.gz"
-  fi
 }
 
 
@@ -249,6 +90,3 @@ install_man_pages() {
 
     return 0
 }
-
-
-#install_erlang $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,29 +1,12 @@
 #!/usr/bin/env bash
 
-versions_list=(
-  17.0
-  17.1
-  17.3
-  17.4
-  17.5
-  18.0
-  18.1
-  18.2.1
-  18.3
-  19.0
-  19.1
-  19.2
-  19.3
-  20.0
-  20.1
-  20.2
-)
+source "$(dirname $0)/utils.sh"
 
-versions=""
+list_all() {
+    ensure_kerl_installed
+    update_available_versions
 
-for version in "${versions_list[@]}"
-do
-  versions="${versions} ${version}"
-done
+    echo "$("$(kerl_path)" list releases | sed -e 's:Run.*::')"
+}
 
-echo $versions
+list_all

--- a/bin/list-all
+++ b/bin/list-all
@@ -3,8 +3,7 @@
 source "$(dirname $0)/utils.sh"
 
 list_all() {
-    ensure_kerl_installed
-    update_available_versions
+    ensure_kerl_setup
 
     echo "$("$(kerl_path)" list releases | sed -e 's:Run.*::')"
 }

--- a/bin/uninstall
+++ b/bin/uninstall
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+source "$(dirname $0)/utils.sh"
+
+$(kerl_path) delete build "asdf_$ASDF_INSTALL_VERSION"
+$(kerl_path) delete installation "$ASDF_INSTALL_PATH"
+rm -rf "$ASDF_INSTALL_PATH"

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -6,7 +6,8 @@ ensure_kerl_installed() {
 
 download_kerl() {
     echo "Downloading kerl..."
-    local kerl_url="https://raw.githubusercontent.com/kerl/kerl/1.8.1/kerl"
+    local kerl_version="1.8.1"
+    local kerl_url="https://raw.githubusercontent.com/kerl/kerl/${kerl_version}/kerl"
     curl -Lo $kerl_url "$(kerl_path)"
     chmod +x "$(kerl_path)"
 }
@@ -14,4 +15,8 @@ download_kerl() {
 kerl_path() {
     # TODO: This may be wrong
     "kerl"
+}
+
+update_available_versions() {
+    "$(kerl_path)" update releases
 }

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -5,17 +5,20 @@ ensure_kerl_installed() {
 }
 
 download_kerl() {
-    echo "Downloading kerl..."
+    # Print to stderr so asdf doesn't assume this string is a list of versions
+    echo "Downloading kerl..." >&2
+
     local kerl_version="1.8.1"
     local kerl_url="https://raw.githubusercontent.com/kerl/kerl/${kerl_version}/kerl"
-    curl -Lso $kerl_url "$(kerl_path)"
+
+    curl -Lso "$(kerl_path)" $kerl_url
     chmod +x "$(kerl_path)"
 }
 
 kerl_path() {
-    echo "kerl"
+    echo "$(dirname "$(dirname $0)")/kerl"
 }
 
 update_available_versions() {
-    "$(kerl_path)" update releases
+   "$(kerl_path)" update releases > /dev/null
 }

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -8,13 +8,12 @@ download_kerl() {
     echo "Downloading kerl..."
     local kerl_version="1.8.1"
     local kerl_url="https://raw.githubusercontent.com/kerl/kerl/${kerl_version}/kerl"
-    curl -Lo $kerl_url "$(kerl_path)"
+    curl -Lso $kerl_url "$(kerl_path)"
     chmod +x "$(kerl_path)"
 }
 
 kerl_path() {
-    # TODO: This may be wrong
-    "kerl"
+    echo "kerl"
 }
 
 update_available_versions() {

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -1,3 +1,9 @@
+ensure_kerl_setup() {
+  set_kerl_env
+  ensure_kerl_installed
+  update_available_versions
+}
+
 ensure_kerl_installed() {
     if [ ! -f "$(kerl_path)" ]; then
         download_kerl
@@ -19,6 +25,14 @@ kerl_path() {
     echo "$(dirname "$(dirname $0)")/kerl"
 }
 
+set_kerl_env() {
+    local kerl_home
+    kerl_home="$(dirname "$(dirname "$0")")/kerl-home"
+    mkdir -p "$kerl_home"
+    export KERL_BASE_DIR="$kerl_home"
+    export KERL_CONFIG="$kerl_home/.kerlrc"
+}
+
 update_available_versions() {
-   "$(kerl_path)" update releases > /dev/null
+    "$(kerl_path)" update releases > /dev/null
 }

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -1,0 +1,17 @@
+ensure_kerl_installed() {
+    if [ ! -f "$(kerl_path)" ]; then
+        download_kerl
+    fi
+}
+
+download_kerl() {
+    echo "Downloading kerl..."
+    local kerl_url="https://raw.githubusercontent.com/kerl/kerl/1.8.1/kerl"
+    curl -Lo $kerl_url "$(kerl_path)"
+    chmod +x "$(kerl_path)"
+}
+
+kerl_path() {
+    # TODO: This may be wrong
+    "kerl"
+}


### PR DESCRIPTION
This PR is inspired by:

* https://github.com/eproxus/asdf-kerl
* https://github.com/tuvistavie/asdf-python
* https://github.com/asdf-vm/asdf-ruby/pull/51

And aims to address issue #53.

Benefits over the existing asdf-erlang code:
* Simpler code, we just use kerl and get all the benefits that it provides

Benefits over asdf-kerl:
* Some code to symlink app-specific executables to the bin directory that asdf looks for, so all Erlang executables are on the path.
* Installs kerl automatically inside the plugin