### PR TITLE
Use "git" kerl backend to support installation of patch releases

### DIFF
--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -30,6 +30,7 @@ set_kerl_env() {
     kerl_home="$(dirname "$(dirname "$0")")/kerl-home"
     mkdir -p "$kerl_home"
     export KERL_BASE_DIR="$kerl_home"
+    export KERL_BUILD_BACKEND="git"
     export KERL_CONFIG="$kerl_home/.kerlrc"
 }
 


### PR DESCRIPTION
The `ref:OTP-20.1.2` syntax described in i.e. #42 and #48 no longer work after the transition to use `kerl` under the hood, when #54 got merged. This environment variable instructs `kerl` to parse Git tags rather than the original source (erlang.org?).

If the maintainers would prefer, I can instead submit a documentation update, as this configuration can also be placed in `~/.kerlrc`.

Ref: https://github.com/kerl/kerl/issues/240