### PR TITLE
Add support for building from git

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ $ export KERL_CONFIGURE_OPTIONS="--disable-debug --without-javac"
 $ asdf install erlang <version>
 ```
 
+You can also install Erlang from git, or provide the url to a fork and build from git.
+
+```
+$ asdf install erlang ref:master
+
+$ export OTP_GITHUB_URL="https://github.com/basho/otp"
+$ asdf install erlang ref:basho
+```
+
 See [kerl](https://github.com/kerl/kerl) for the complete list of customization options. Note that the `KERL_BASE_DIR` and `KERL_CONFIG` environment variables are set by the plugin when it runs kerl so it will not be possible to customize them.
 
 ## Before `asdf install`

--- a/bin/install
+++ b/bin/install
@@ -8,7 +8,14 @@ install_erlang() {
   ensure_kerl_setup
 
   export MAKEFLAGS="-j$ASDF_CONCURRENCY"
-  $(kerl_path) build "$ASDF_INSTALL_VERSION" "asdf_$ASDF_INSTALL_VERSION"
+  if [ "$ASDF_INSTALL_TYPE" = "ref" ]; then
+    local asdf_activation_version="$ASDF_INSTALL_TYPE:$ASDF_INSTALL_VERSION"
+    $(kerl_path) build git "${OTP_GITHUB_URL:-https://github.com/erlang/otp.git}" "$ASDF_INSTALL_VERSION" "asdf_$ASDF_INSTALL_VERSION"
+  else
+    local asdf_activation_version="$ASDF_INSTALL_VERSION"
+    $(kerl_path) build "$ASDF_INSTALL_VERSION" "asdf_$ASDF_INSTALL_VERSION"
+  fi
+
   $(kerl_path) install "asdf_$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"
   $(kerl_path) cleanup "$ASDF_INSTALL_VERSION"
 
@@ -36,11 +43,11 @@ install_erlang() {
   echo
   echo "Erlang $ASDF_INSTALL_VERSION has been installed. Activate globally with:"
   echo
-  echo "    asdf global erlang $ASDF_INSTALL_VERSION"
+  echo "    asdf global erlang $asdf_activation_version"
   echo
   echo "Activate locally in the current folder with:"
   echo
-  echo "    asdf local erlang $ASDF_INSTALL_VERSION"
+  echo "    asdf local erlang $asdf_activation_version"
   echo
 }
 


### PR DESCRIPTION
An option is to set `OTP_GITHUB_URL`, similar to kerl, to build from a specific repo.

Solves #59