### PR TITLE
add basic docs for centos

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,25 +31,25 @@ tested on Ubuntu 16.04 LTS, "Xenial Xerus"). Note that if you are using a
 previous version of Linux, you may need a different version of one of the below
 libraries.
 
-Install the build tools (dpkg-dev g++ gcc libc6-dev make)  
+Install the build tools (dpkg-dev g++ gcc libc6-dev make)
 `apt-get -y install build-essential`
 
-Automatic configure script builder (debianutils m4 perl)  
+Automatic configure script builder (debianutils m4 perl)
 `apt-get -y install autoconf`
 
-Needed for HiPE (native code) support, but already installed by autoconf  
+Needed for HiPE (native code) support, but already installed by autoconf
 `apt-get -y install m4`
 
-Needed for terminal handling (libc-dev libncurses5 libtinfo-dev libtinfo5 ncurses-bin)  
+Needed for terminal handling (libc-dev libncurses5 libtinfo-dev libtinfo5 ncurses-bin)
 `apt-get -y install libncurses5-dev`
 
-For building with wxWidgets (start observer or debugger!)  
+For building with wxWidgets (start observer or debugger!)
 `apt-get -y install libwxgtk3.0-dev libgl1-mesa-dev libglu1-mesa-dev libpng3`
 
-For building ssl (libssh-4 libssl-dev zlib1g-dev)  
+For building ssl (libssh-4 libssl-dev zlib1g-dev)
 `apt-get -y install libssh-dev`
 
-ODBC support (libltdl3-dev odbcinst1debian2 unixodbc)  
+ODBC support (libltdl3-dev odbcinst1debian2 unixodbc)
 `apt-get -y install unixodbc-dev`
 
 # Arch Linux
@@ -59,15 +59,44 @@ Provides most of the needed build tools.
 Needed for terminal handling
 `pacman -S curses`
 
-For building with wxWidgets (start observer or debugger!)  
+For building with wxWidgets (start observer or debugger!)
 `pacman -S glu mesa wxgtk2 libpng`
 
-For building ssl  
+For building ssl
 `pacman -S libssh`
 
 ODBC support
 `sudo pacman -S unixodbc`
 
 # OSX
-For building with wxWidgets (start observer or debugger!)  
+For building with wxWidgets (start observer or debugger!)
 `brew install wxmac`
+
+# CentOS
+
+These steps assume a most recent build of CentOS (currently
+tested on CentOS 7.5 x64)
+
+Install the build tools
+`sudo yum groupinstall -y 'Development Tools'`
+
+Automatic configure script builder
+`sudo yum install -y autoconf`
+
+Needed for terminal handling
+`sudo yum install -y ncurses-devel`
+
+For building with wxWidgets (start observer or debugger!)
+`sudo yum install -y wxGTK-devel wxBase`
+
+For building ssl
+`sudo yum install -y openssl-devel`
+
+for jinterface
+`sudo yum install -y java-1.8.0-openjdk-devel`
+
+ODBC support
+`sudo yum install -y install libiodbc unixODBC.x86_64 erlang-odbc.x86_64`
+
+for the documentation to be built
+`sudo yum install -y libxslt`


### PR DESCRIPTION
added basic docs for installation with centos
note that despite my best efforts, I couldn't get rid of the following warnings.
```
APPLICATIONS DISABLED (See: /root/.asdf/plugins/erlang/kerl-home/builds/asdf_20.3/otp_build_20.3.log)
 * odbc           : ODBC library - link check failed

DOCUMENTATION INFORMATION (See: /root/.asdf/plugins/erlang/kerl-home/builds/asdf_20.3/otp_build_20.3.log)
 * documentation  :
 *                  fop is missing.
 *                  Using fakefop to generate placeholder PDF files.
```
Let me know if you want/need any changes