### PR TITLE
travis_wait for when build exceeds 10 minutes, default max duration is 20 minutes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-script: asdf plugin-test erlang https://github.com/asdf-vm/asdf-erlang.git
+script: travis_wait asdf plugin-test erlang https://github.com/asdf-vm/asdf-erlang.git
 before_script:
   - git clone https://github.com/asdf-vm/asdf.git
   - . asdf/asdf.sh


### PR DESCRIPTION
This should fix travis on PRs. You can also pass it a higher number like `travis_wait 30 YOUR_COMMAND`, but I don't think that is necessary.