### PR TITLE
fix: downloading man pages

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -5,9 +5,14 @@ set -e
 source "$(dirname $0)/utils.sh"
 
 install_erlang() {
-  ensure_kerl_setup
 
+  ensure_kerl_setup
   export MAKEFLAGS="-j$ASDF_CONCURRENCY"
+  local tmp_download_dir=$(set_tmp_dir)
+  local install_type=$ASDF_INSTALL_TYPE
+  local install_path=$ASDF_INSTALL_PATH
+  local version=$ASDF_INSTALL_VERSION
+
   if [ "$ASDF_INSTALL_TYPE" = "ref" ]; then
     local asdf_activation_version="$ASDF_INSTALL_TYPE:$ASDF_INSTALL_VERSION"
     $(kerl_path) build git "${OTP_GITHUB_URL:-https://github.com/erlang/otp.git}" "$ASDF_INSTALL_VERSION" "asdf_$ASDF_INSTALL_VERSION"
@@ -19,26 +24,27 @@ install_erlang() {
   $(kerl_path) install "asdf_$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"
   $(kerl_path) cleanup "$ASDF_INSTALL_VERSION"
 
-#    # I don't know how to install docs for tags
-#    if [ "$install_type" = "version" ]; then
-#        if install_man_pages; then
-#            echo "Downloading man pages"
-#            local source_path=$(get_docs_download_file_path $version $tmp_download_dir)
-#            download_docs $version $source_path
-#
-#            cd $(dirname $source_path)
-#            tar -xzvf $source_path || exit 1
-#
-#            # Place the `man` directory in the Erlang install
-#            mv man $install_path/lib/erlang/
-#        else
-#            echo "Skipping install of man pages"
-#        fi
-#    else
-#        echo "Skipping install of man pages"
-#    fi
+   if [ "$install_type" = "version" ]; then
+       if install_man_pages; then
+           echo "Downloading man pages"
+           local source_path=$(get_docs_download_file_path $version $tmp_download_dir)
+           download_docs $version $source_path
 
-  link_app_executables $ASDF_INSTALL_PATH
+           cd $(dirname $source_path)
+           tar -xzf $source_path || exit 1
+
+           # Place the `man` directory in the Erlang install
+           mv man $install_path
+           # remove temporary directory into which erlang manual has been downloaded
+           rm $(dirname $source_path) -rf
+       else
+           echo "Skipping install of man pages"
+       fi
+   else
+       echo "(version check) Skipping install of man pages"
+   fi
+
+  link_app_executables $install_path
   
   echo
   echo "Erlang $ASDF_INSTALL_VERSION has been installed. Activate globally with:"
@@ -49,6 +55,15 @@ install_erlang() {
   echo
   echo "    asdf local erlang $asdf_activation_version"
   echo
+}
+
+set_tmp_dir() {
+  if [ "$TMPDIR" = "" ]; then
+    local tmp_download_dir=$(mktemp -d -t erlang_build_XXXXXX)
+  else
+    local tmp_download_dir=$TMPDIR
+  fi
+  echo "$tmp_download_dir"
 }
 
 link_app_executables() {
@@ -64,7 +79,7 @@ download_docs() {
   local download_path=$2
   local download_url=$(get_docs_download_url $version)
 
-  curl -Lo $download_path -C - $download_url
+  curl $download_url -Lo $download_path
 }
 
 
@@ -77,10 +92,24 @@ get_docs_download_file_path() {
 }
 
 
+get_docs_version() {
+  local version=$1
+  local version_string_length=`expr length $version`
+  local fst=`expr index $version .`
+  local version_part=${version:$fst:$version_string_length-$fst}
+  local snd=`expr index $version_part .`
+  if [ $snd == "0" ]; then
+    local docversion=$version
+  else
+    local docversion="${version:0:$fst+$snd-1}"
+  fi
+  echo $docversion
+}
+
 get_docs_download_url() {
   local version=$1
-
-  echo "http://www.erlang.org/download/otp_doc_man_${version}.tar.gz"
+  local docversion=$(get_docs_version $version)
+  echo "http://www.erlang.org/download/otp_doc_man_${docversion}.tar.gz"
 }
 
 


### PR DESCRIPTION
This fix should result in downloading Erlang man pages as a part of the installation of specific Erlang version.

1. Empty install_type has been fixed (ASDF_INSTALL_TYPE was not assigned to it).
2. Tar now runs in quiet mode.
3. Temporary directory is cleaned at the end of the installation process.
4. Important note: man pages version seem to always include only major & minor, so for 20.3.1 and 20.3.3 it is 20.3, and for version a.b.c.d (19.3.6.9) it is a.b (19.3).