### PR TITLE
install manpages via kerl

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ For building ssl (libssh-4 libssl-dev zlib1g-dev)
 ODBC support (libltdl3-dev odbcinst1debian2 unixodbc)
 `apt-get -y install unixodbc-dev`
 
+For building documentation:
+`apt get install xsltproc fop`
+
 ## Arch Linux
 Provides most of the needed build tools.
 `pacman -S --needed base-devel`

--- a/bin/install
+++ b/bin/install
@@ -7,8 +7,6 @@ source "$(dirname $0)/utils.sh"
 install_erlang() {
   ensure_kerl_setup
 
-  local tmp_download_dir=$(set_tmp_dir)
-
   # tell kerl to build documentattion (html & man pages)
   export KERL_BUILD_DOCS=yes
   
@@ -37,15 +35,6 @@ install_erlang() {
   echo
   echo "    asdf local erlang $asdf_activation_version"
   echo
-}
-
-set_tmp_dir() {
-  if [ "$TMPDIR" = "" ]; then
-    local tmp_download_dir=$(mktemp -d -t erlang_build_XXXXXX)
-  else
-    local tmp_download_dir=$TMPDIR
-  fi
-  echo "$tmp_download_dir"
 }
 
 link_app_executables() {

--- a/bin/install
+++ b/bin/install
@@ -7,6 +7,11 @@ source "$(dirname $0)/utils.sh"
 install_erlang() {
   ensure_kerl_setup
 
+  local tmp_download_dir=$(set_tmp_dir)
+
+  # tell kerl to build documentattion (html & man pages)
+  export KERL_BUILD_DOCS=yes
+  
   export MAKEFLAGS="-j$ASDF_CONCURRENCY"
   if [ "$ASDF_INSTALL_TYPE" = "ref" ]; then
     local asdf_activation_version="$ASDF_INSTALL_TYPE:$ASDF_INSTALL_VERSION"
@@ -19,24 +24,7 @@ install_erlang() {
   $(kerl_path) install "asdf_$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"
   $(kerl_path) cleanup "$ASDF_INSTALL_VERSION"
 
-#    # I don't know how to install docs for tags
-#    if [ "$install_type" = "version" ]; then
-#        if install_man_pages; then
-#            echo "Downloading man pages"
-#            local source_path=$(get_docs_download_file_path $version $tmp_download_dir)
-#            download_docs $version $source_path
-#
-#            cd $(dirname $source_path)
-#            tar -xzvf $source_path || exit 1
-#
-#            # Place the `man` directory in the Erlang install
-#            mv man $install_path/lib/erlang/
-#        else
-#            echo "Skipping install of man pages"
-#        fi
-#    else
-#        echo "Skipping install of man pages"
-#    fi
+  unset KERL_BUILD_DOCS
 
   link_app_executables $ASDF_INSTALL_PATH
   
@@ -51,57 +39,21 @@ install_erlang() {
   echo
 }
 
+set_tmp_dir() {
+  if [ "$TMPDIR" = "" ]; then
+    local tmp_download_dir=$(mktemp -d -t erlang_build_XXXXXX)
+  else
+    local tmp_download_dir=$TMPDIR
+  fi
+  echo "$tmp_download_dir"
+}
+
 link_app_executables() {
     local install_path=$1
 
     # Link other executables to the bin directory so that asdf shims are created for them
     cd "$install_path/bin"
     ln -s ../lib/*/bin/* ../lib/*/priv/bin/* .
-}
-
-download_docs() {
-  local version=$1
-  local download_path=$2
-  local download_url=$(get_docs_download_url $version)
-
-  curl -Lo $download_path -C - $download_url
-}
-
-
-get_docs_download_file_path() {
-  local version=$1
-  local tmp_download_dir=$2
-  local pkg_name="otp_doc_man_${version}.tar.gz"
-
-  echo "$tmp_download_dir/$pkg_name"
-}
-
-
-get_docs_download_url() {
-  local version=$1
-
-  echo "http://www.erlang.org/download/otp_doc_man_${version}.tar.gz"
-}
-
-
-install_man_pages() {
-    OPTIONS=$ASDF_ERLANG_OPTIONS
-
-    while :; do
-        case ${OPTIONS:-} in
-            -n|--no-docs)
-                return 1
-                ;;
-            *)
-                if [ -z "${OPTIONS:-}" ]; then
-                    break
-                fi
-        esac
-
-        shift
-    done
-
-    return 0
 }
 
 install_erlang


### PR DESCRIPTION
This fix uses kerl to install documentation as part of Erlang installation 
The best/easiest way to achieve this is to set KERL_BUILD_DOCS environment variable (and unset it, after installation).

Using kerl to build documentation instead of downloading and extracting tarbal makes installation of Erlang a bit longer.

Unused code was removed (40% of lines were removed in total).

Please note: installing documentation requires `xsltproc` and `fop`. Readme has been updated (Debian/Ubuntu section only - I am not sure how it works on other systems).