### PR TITLE
add install autoconf to OSX build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ ODBC support
 `sudo pacman -S unixodbc`
 
 ## OSX
+
+Install the build tools
+`brew install autoconf`
+
 For building with wxWidgets (start observer or debugger!)
 `brew install wxmac`
 


### PR DESCRIPTION
autoconf is required for compiling erlang from source.