### PR TITLE
do not remove KERL_BUILD_DOCS as user may want to have it set

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -19,8 +19,6 @@ install_erlang() {
   $(kerl_path) install "asdf_$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"
   $(kerl_path) cleanup "$ASDF_INSTALL_VERSION"
 
-  unset KERL_BUILD_DOCS
-
   link_app_executables $ASDF_INSTALL_PATH
   
   echo


### PR DESCRIPTION
As KERL_BUILD_DOCS was removed to allow for better flexibility (having the docs installed or not) this should be removed as well. User may want to have this environment variable set at all times, so when Erlang is installed it installs docs by default.