### PR TITLE
Install documentation for Erlang (no additional dependencies required)

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -16,8 +16,14 @@ install_erlang() {
     $(kerl_path) build "$ASDF_INSTALL_VERSION" "asdf_$ASDF_INSTALL_VERSION"
   fi
 
+  export KERL_INSTALL_MANPAGES=yes
+  export KERL_INSTALL_HTMLDOCS=yes
+
   $(kerl_path) install "asdf_$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"
   $(kerl_path) cleanup "$ASDF_INSTALL_VERSION"
+
+  unset KERL_INSTALL_MANPAGES
+  unset KERL_INSTALL_HTMLDOCS
 
   link_app_executables $ASDF_INSTALL_PATH
   


### PR DESCRIPTION
According to the discussion we have (https://github.com/asdf-vm/asdf-erlang/commit/716d94174956ccbb0f771febe87e02c8df09ba56#comments) I have created this small patch. This should allow having documentation installed without relying on `fop` and `xsltproc` (or similar packages).

I have tried that on one machine and it seems to work fine. I am planning to check this installation on a clean machine later this week.

I think the section related to obtaining documentation should be updated (once again) - reference to `KERL_BUILD_DOCS` should be completely removed. 