### PR TITLE
Fix Newline Issue with `list-all` Command

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -5,7 +5,7 @@ source "$(dirname $0)/utils.sh"
 list_all() {
     ensure_kerl_setup
 
-    echo "$("$(kerl_path)" list releases | sed -e 's:Run.*::')"
+    echo "$("$(kerl_path)" list releases | sed -e 's:Run.*::' | tr '\n' ' ')"
 }
 
 list_all


### PR DESCRIPTION
Context: In kerl 1.8.3, the way that release lists are read seems to have changed. As a result, version numbers are separated by newlines instead of spaces. asdf appears to require version lists to reported as space-separated lists. This change removes newlines from the list of releases reported by `kerl`.

This change Works On My Machine (TM) but needs further thought:

- Should we try to use `sed` instead of `tr`?
- Is there a more robust way to format the output?

See #88.