### PR TITLE
Update requirements for wx on Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ These steps assume a most recent build of CentOS (currently
 tested on CentOS 7.5 x64 & Fedora 28 x64)
 
 Install the build tools
-`sudo yum groupinstall -y 'Development Tools'`
+`sudo yum groupinstall -y 'Development Tools' 'C Development Tools and Libraries'`
 
 Automatic configure script builder
 `sudo yum install -y autoconf`
@@ -103,7 +103,7 @@ Needed for terminal handling
 `sudo yum install -y ncurses-devel`
 
 For building with wxWidgets (start observer or debugger!)
-`sudo yum install -y wxGTK-devel wxBase`
+`sudo yum install -y wxGTK3-devel wxBase3`
 
 For building ssl
 `sudo yum install -y openssl-devel`


### PR DESCRIPTION
I had a bit of fun getting erlang to build on Fedora 28. This pull request is the changes I discovered I had to make:

Erlang now specifies wxWidgets 3.0
(http://erlang.org/doc/installation_guide/INSTALL.html#Advanced-configuration-and-build-of-ErlangOTP_Building_Building-with-wxErlang)

Building wx also need g++ available, and that isn't installed by 'Development
Tools', so we bring in the C Development Tools package.