### PR TITLE
Add installation guide to for Solus

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,41 @@ ODBC support
 for the documentation to be built
 `sudo yum install -y libxslt`
 
+## Solus
+
+Install the build tools
+`sudo eopkg it -c system.devel`
+
+For building wxWidgets
+`sudo eopkg install wxwidgets-devel mesalib-devel libglu-devel`
+
+For ODBC support
+`sudo eopkg install unixodbc-devel`
+
+For jinterface
+`sudo eopkg install openjdk-8-devel`
+
+If you want to install all of the above
+
+```bash
+sudo eopkg it -c system.devel
+
+sudo eopkg install wxwidgets-devel mesalib-devel libglu-devel unixodbc-devel openjdk-8-devel
+```
+
+### Dealing with OpenJDK issues on Solus
+
+I ran into an issue where `javac` wasn't a recognized command in the terminal despite having installed `openjdk-8` and `openjdk-8-devel`. Turns out it wasn't added to `PATH` by default. So simply add it to `PATH` like so:
+
+```bash
+# In ~/.bashrc add these to add Java to PATH
+JAVA_HOME=/usr/lib64/openjdk-8
+PATH=$PATH:$JAVA_HOME/bin
+
+# In terminal
+source ~/.bashrc
+```
+
 ## Getting Erlang documentation
 
 Erlang may come with documentation included (as man pages, pdfs and html files). This allows typing `erl -man mnesia` to get info on `mnesia` module. asdf-erlang uses kerl for builds, and [kerl](https://github.com/kerl/kerl) is capable of building the docs for specified version of Erlang. 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ sudo eopkg install wxwidgets-devel \
                    mesalib-devel \
                    libglu-devel \
                    unixodbc-devel \
+                   openjdk-8 \
                    openjdk-8-devel
 ```
 

--- a/README.md
+++ b/README.md
@@ -146,23 +146,42 @@ for the documentation to be built
 ## Solus
 
 Install the build tools
-`sudo eopkg it -c system.devel`
+
+```bash
+sudo eopkg it -c system.devel
+```
 
 For building wxWidgets
-`sudo eopkg install wxwidgets-devel mesalib-devel libglu-devel`
+
+```bash
+sudo eopkg install wxwidgets-devel \
+                    mesalib-devel 
+                    libglu-devel
+```
 
 For ODBC support
-`sudo eopkg install unixodbc-devel`
+
+```bash
+sudo eopkg install unixodbc-devel
+```
 
 For jinterface
-`sudo eopkg install openjdk-8-devel`
+
+```bash
+sudo eopkg install openjdk-8 \
+                   openjdk-8-devel
+```
 
 If you want to install all of the above
 
 ```bash
 sudo eopkg it -c system.devel
 
-sudo eopkg install wxwidgets-devel mesalib-devel libglu-devel unixodbc-devel openjdk-8-devel
+sudo eopkg install wxwidgets-devel \ 
+                   mesalib-devel \
+                   libglu-devel \
+                   unixodbc-devel \
+                   openjdk-8-devel
 ```
 
 ### Dealing with OpenJDK issues on Solus


### PR DESCRIPTION
Since Solus does not share the same repositories with Debian/Ubuntu, it will be challenging for beginners to set up Erlang without seeing a lot of errors with missing dependencies. This PR includes the packages necessary to be installed to address all of the missing dependency error messages, and addresses an issue I encountered while installing regarding `jinterface`.

![image](https://user-images.githubusercontent.com/20364796/82634542-84499700-9c30-11ea-8d42-dacb16a85003.png)
