### PR TITLE
Update package list before install packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ If you want to install all the above:
 ### Ubuntu 20.04 LTS
 
 If you want to install all the above: 
-`apt-get -y install build-essential autoconf m4 libncurses5-dev libwxgtk3.0-gtk3-dev libgl1-mesa-dev libglu1-mesa-dev libpng-dev libssh-dev unixodbc-dev xsltproc fop libxml2-utils libncurses-dev openjdk-11-jdk`
+`apt-get update -y && apt-get -y install build-essential autoconf m4 libncurses5-dev libwxgtk3.0-gtk3-dev libgl1-mesa-dev libglu1-mesa-dev libpng-dev libssh-dev unixodbc-dev xsltproc fop libxml2-utils libncurses-dev openjdk-11-jdk`
 
 ## Arch Linux
 Provides most of the needed build tools.


### PR DESCRIPTION
Some packages require updating list before install.

For example, `libwxgtk3.0-gtk3-dev` produced an `unable to locate package` error on my local machine.