### PR TITLE
Add fop and unixODBC-devel in README Fedora/CentOS dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,10 +141,10 @@ for jinterface
 `sudo yum install -y java-1.8.0-openjdk-devel`
 
 ODBC support
-`sudo yum install -y libiodbc unixODBC.x86_64 erlang-odbc.x86_64`
+`sudo yum install -y libiodbc unixODBC-devel.x86_64 erlang-odbc.x86_64`
 
 for the documentation to be built
-`sudo yum install -y libxslt`
+`sudo yum install -y libxslt fop`
 
 ## Solus
 


### PR DESCRIPTION
See #100
I'm not sure the issue should be closed with this PR because the issue affected several OS, not just CentOS/Fedora.