### PR TITLE
Bump kerl version

### DIFF
--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -1,4 +1,4 @@
-KERL_VERSION="2.0.0"
+KERL_VERSION="2.0.1"
 
 ensure_kerl_setup() {
   set_kerl_env


### PR DESCRIPTION
Bump the `kerl` version to 2.0.1 which have resume download on corrupted Erlang tarball from GitHub (https://github.com/kerl/kerl/pull/348). This fixes the issue of interrupted downloads are treated as correct downloads (https://github.com/asdf-vm/asdf-erlang/issues/111).

Before.
```
$ asdf install erlang 23.0-rc1
Downloading OTP-23.0-rc1.tar.gz to /home/foobar/.asdf/plugins/erlang/kerl-home/archives...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   124  100   124    0     0    163      0 --:--:-- --:--:-- --:--:--   163
 14 53.5M   14 8005k    0     0   787k      0  0:01:09  0:00:10  0:00:59 1284k^C
received sigint, cleaning up
...

$ asdf install erlang 23.0-rc1
Extracting source code

gzip: stdin: unexpected end of file
tar: Unexpected EOF in archive
tar: Unexpected EOF in archive
tar: Error is not recoverable: exiting now
Building Erlang/OTP 23.0-rc1 (asdf_23.0-rc1), please wait...
^C
received sigint, cleaning up
...
```

After.
```
$ asdf install erlang 23.0-rc1
/home/foobar/.asdf/plugins/erlang/kerl-home/archives/OTP-23.0-rc1.tar.gz corrupted and redownloading...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   124  100   124    0     0    135      0 --:--:-- --:--:-- --:--:--   135
 54 53.5M   54 29.4M    0     0  1541k      0  0:00:35  0:00:19  0:00:16 3700k^C
...
```

