### PR TITLE
Bump kerl version to 2.0.2

### DIFF
--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -1,4 +1,4 @@
-KERL_VERSION="2.0.1"
+KERL_VERSION="2.0.2"
 
 ensure_kerl_setup() {
   set_kerl_env


### PR DESCRIPTION
Bump kerl version to 2.0.2 to fix building Erlang on Big Sur.