### PR TITLE
Warn macOS users about kerl's supported versions?

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ ODBC support
 
 ## OSX
 
+Warning: 22.3.1 is the earliest version that can be installed through `kerl` (and, therefore, `asdf`). Earlier versions will fail to compile. See [this issue](https://github.com/kerl/kerl/issues/335#issuecomment-605487028) for details.
+
 Install the build tools
 `brew install autoconf`
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ ODBC support
 
 ## OSX
 
-Warning: 22.3.1 is the earliest version that can be installed through `kerl` (and, therefore, `asdf`). Earlier versions will fail to compile. See [this issue](https://github.com/kerl/kerl/issues/335#issuecomment-605487028) for details.
+Note, for MacOS 10.15.4 and newer, 22.3.1 is the earliest version that can be installed through `kerl` (and, therefore, `asdf`). Earlier versions will fail to compile. See [this issue](https://github.com/kerl/kerl/issues/335#issuecomment-605487028) for details.
 
 Install the build tools
 `brew install autoconf`


### PR DESCRIPTION
Took me some trail/error/googling to figure this out. Loving `asdf` though!

Also wonder, if this seems like a good change, perhaps `asdf-erlang` itself could warn macOS users?