### PR TITLE
Bump kerl to 2.1.1

### DIFF
--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -1,4 +1,4 @@
-KERL_VERSION="2.1.0"
+KERL_VERSION="2.1.1"
 
 ensure_kerl_setup() {
   set_kerl_env


### PR DESCRIPTION
> 22 March 2021 - 2.1.1
> - grep with-ssl (#367)
> - Add a \ to commands to bypass any shell alias (#363)
> - Enable multiple doc targets (#362)

from [kerl changelog](https://github.com/kerl/kerl#changelog)