### PR TITLE
Bump kerl to 2.2.0

### DIFF
--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -1,4 +1,4 @@
-KERL_VERSION="2.1.2"
+KERL_VERSION="2.2.0"
 
 handle_failure() {
   function=$1


### PR DESCRIPTION
kerl 2.2.0 includes a significant build time improvement (by using pre-built binaries from official OTP github releases) ([PR](https://github.com/kerl/kerl/pull/376))