### PR TITLE
Rename wxmac to wxwidgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Install OpenSSL
 `brew install openssl`
 
 For building with wxWidgets (start observer or debugger!)
-`brew install wxmac`
+`brew install wxwidgets`
 
 #### Dealing with OpenSSL issues on macOS
 


### PR DESCRIPTION
The homebrew package `wxmac` has been recently renamed to `wxwidgets`. The old reference still works, but I think it's less confusing to use the new one (as this is what appears in your `brew list` after installation).

See: https://formulae.brew.sh/formula/wxwidgets