### PR TITLE
Bump kerl to 2.2.2

### DIFF
--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -1,4 +1,4 @@
-KERL_VERSION="2.2.1"
+KERL_VERSION="2.2.2"
 
 handle_failure() {
   function=$1


### PR DESCRIPTION
kerl 2.2.2 includes a fix for building older versions of OTP on macOS
Big Sur and above. Closes #228.

<https://github.com/kerl/kerl/compare/2.2.1...2.2.2>