### PR TITLE
Show progress when downloading `kerl`.

### DIFF
--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -47,7 +47,7 @@ download_kerl() {
 
     local kerl_url="https://raw.githubusercontent.com/kerl/kerl/${KERL_VERSION}/kerl"
 
-    curl -Lso "$(kerl_path)" $kerl_url
+    curl -Lo "$(kerl_path)" $kerl_url
     chmod +x "$(kerl_path)"
 }
 


### PR DESCRIPTION
Show progress so when there's a network issue, it won't confuse the user on installing `kerl`.
This should also resolve issue like #174

## Example

Before

```shell
$ asdf install erlang 23.
Downloading kerl...
chmod: /Users/jun/.asdf/plugins/erlang/kerl: No such file or directory
Failed to install kerl
```

After

```shell
$ asdf install erlang 23.
Downloading kerl...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (7) Failed to connect to raw.githubusercontent.com port 443: Connection refused
chmod: /Users/jun/.asdf/plugins/erlang/kerl: No such file or directory
Failed to install kerl
```