### PR TITLE
Force user to provide a version when uninstall

### DIFF
--- a/bin/uninstall
+++ b/bin/uninstall
@@ -11,6 +11,11 @@ source "$(dirname "$0")/utils.sh"
 
 ensure_kerl_setup
 
+if [ "$ASDF_INSTALL_VERSION" == "" ]; then
+    echo "Please provide the version you want to uninstall"
+    exit 1
+fi
+
 # Remove the installation and build if the installation was done by kerl
 if $(kerl_path) list installations | grep "$ASDF_INSTALL_PATH"; then
     $(kerl_path) delete build "asdf_$ASDF_INSTALL_VERSION" || true


### PR DESCRIPTION
As described in #266, if user type `asdf uninstall erlang` without a version, the kerl installation state will be break. The packages will be removed (i.e. the directory `~/.asdf/installs/erlang/` will be empty. However a re-installation on the same version will not work (unless manually touch files like `~.asdf/plugins/erlang/kerl-home/otp_installation`.

This PR can prevent that situation. Other options may also possible, please guide me if we want go other options.

P.S I didn't add validation on version provided, since if the user type a `asdf uninstall erlang <version-non-exists>`, adsf would tell and refuse to continue, which is cool!