### PR TITLE
Erlang support OpenSSL 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ Install the build tools
 Install OpenSSL
 `brew install openssl@1.1`  _Erlang 24.1 and older require OpenSSL 1.1, [read more here](https://github.com/erlang/otp/issues/4577#issuecomment-925962048)_
 
-Note, Erlang 25.1 and newer, [support OpenSSL 3.0, even for production use.](https://github.com/erlang/otp/releases/tag/OTP-25.1) 
-If necessary, you can install the latest version of OpenSSL `brew install openssl`
+Note, Erlang 25.1 and newer [support OpenSSL 3.0, even for production use.](https://github.com/erlang/otp/releases/tag/OTP-25.1) 
+If you want to build Erlang with openssl@3.0, install it by `brew install openssl`
 
 For building with wxWidgets (start observer or debugger!). Note that you may need to select the right `wx-config` before installing Erlang.
 `brew install wxwidgets`

--- a/README.md
+++ b/README.md
@@ -102,8 +102,9 @@ Note, for MacOS 10.15.4 and newer, 22.3.1 is the earliest version that can be in
 Install the build tools
 `brew install autoconf`
 
-Install OpenSSL
-`brew install openssl@1.1`. _Erlang doesn't support openssl 3 yet, [read more here](https://github.com/erlang/otp/issues/4577#issuecomment-925962048)._
+Install OpenSSL `brew install openssl`
+
+Note, Erlang 23 and older, doesn't support openssl 3, [read more here](https://github.com/erlang/otp/issues/4577#issuecomment-925962048): `brew install openssl@1.1`
 
 For building with wxWidgets (start observer or debugger!). Note that you may need to select the right `wx-config` before installing Erlang.
 `brew install wxwidgets`

--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ Install the build tools
 `brew install autoconf`
 
 Install OpenSSL
-`brew install openssl`
+`brew install openssl@1.1`  _Erlang 24.1 and older require OpenSSL 1.1, [read more here](https://github.com/erlang/otp/issues/4577#issuecomment-925962048)_
 
-Note that Erlang 24.1 and older require OpenSSL 1.1, [read more here](https://github.com/erlang/otp/issues/4577#issuecomment-925962048). In addition, from 24.2 to 25.0 recommend using OpenSSL 1.1 instead of OpenSSL 3.0, especially for production use, [read more here](https://github.com/erlang/otp/releases/tag/OTP-25.1). 
-`brew install openssl@1.1`
+Note, Erlang 25.1 and newer, [support OpenSSL 3.0, even for production use.](https://github.com/erlang/otp/releases/tag/OTP-25.1) 
+If necessary, you can install the latest version of OpenSSL `brew install openssl`
 
 For building with wxWidgets (start observer or debugger!). Note that you may need to select the right `wx-config` before installing Erlang.
 `brew install wxwidgets`

--- a/README.md
+++ b/README.md
@@ -102,9 +102,11 @@ Note, for MacOS 10.15.4 and newer, 22.3.1 is the earliest version that can be in
 Install the build tools
 `brew install autoconf`
 
-Install OpenSSL `brew install openssl`
+Install OpenSSL
+`brew install openssl`
 
-Note, Erlang 23 and older, doesn't support openssl 3, [read more here](https://github.com/erlang/otp/issues/4577#issuecomment-925962048): `brew install openssl@1.1`
+Note that Erlang 24.1 and older require OpenSSL 1.1, [read more here](https://github.com/erlang/otp/issues/4577#issuecomment-925962048). In addition, from 24.2 to 25.0 recommend using OpenSSL 1.1 instead of OpenSSL 3.0, especially for production use, [read more here](https://github.com/erlang/otp/releases/tag/OTP-25.1). 
+`brew install openssl@1.1`
 
 For building with wxWidgets (start observer or debugger!). Note that you may need to select the right `wx-config` before installing Erlang.
 `brew install wxwidgets`


### PR DESCRIPTION
Thanks for awesome tool and awesome plugin ✨ 

Erlang already supports openssl3.
So I think doesn't needs to install openssl1.1 in osx section.