### PR TITLE
openSUSE Tumbleweed - ODBC and jinterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Install the build tools
 Install OpenSSL
 `brew install openssl@1.1`  _Erlang 24.1 and older require OpenSSL 1.1, [read more here](https://github.com/erlang/otp/issues/4577#issuecomment-925962048)_
 
-Note, Erlang 25.1 and newer [support OpenSSL 3.0, even for production use.](https://github.com/erlang/otp/releases/tag/OTP-25.1) 
+Note, Erlang 25.1 and newer [support OpenSSL 3.0, even for production use.](https://github.com/erlang/otp/releases/tag/OTP-25.1)
 If you want to build Erlang with openssl@3.0, install it by `brew install openssl`
 
 For building with wxWidgets (start observer or debugger!). Note that you may need to select the right `wx-config` before installing Erlang.
@@ -238,6 +238,18 @@ To build documentation:
 
 ```
 sudo zypper install fop libxml2-tools libxslt-tools
+```
+
+For ODBC support:
+
+```
+sudo zypper install unixODBC-devel
+```
+
+For jinterface:
+
+```
+sudo zypper install java-1_8_0-openjdk-devel
 ```
 
 ## Getting Erlang documentation


### PR DESCRIPTION
Add installation instructions for both ODBC and Java (jinterface support) for openSUSE Tumbleweed to prevent "APPLICATIONS DISABLED" messages during `asdf install`.