### PR TITLE
Update default `kerl` to 4.0.0

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -1,4 +1,4 @@
-export KERL_VERSION="${ASDF_KERL_VERSION:-2.6.0}"
+export KERL_VERSION="${ASDF_KERL_VERSION:-4.0.0}"
 
 handle_failure() {
     function=$1


### PR DESCRIPTION
There seem to be some nice improvements since 2.6.0 that it may be worth having 4.0.0 as the default when not otherwise specified