### PR TITLE
Correct kerl cleanup call in install callback

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -30,7 +30,7 @@ install_erlang() {
     # "You can activate this installation running the following command:"
     # that doesn't apply is hidden
     $(kerl_path) install "$build_name" "$ASDF_INSTALL_PATH" >/dev/null 2>&1
-    $(kerl_path) cleanup "$ASDF_INSTALL_VERSION"
+    $(kerl_path) cleanup "$build_name"
 
     link_app_executables "$ASDF_INSTALL_PATH"
 }


### PR DESCRIPTION
Fixes #280

The cleanup command expects either a build name or the keyword `all`. I was passing in the asdf version, which kerl didn't understand. Passing in the build name like we do for the `kerl install` command fixes this.

Test:

```bash
$ ls ~/.asdf/plugins/erlang/kerl-home/builds
asdf_26.1.1 asdf_26.1.2 asdf_26.2   asdf_26.2.1

$ asdf install erlang 25.3.2.8
asdf_25.3.2.8 is not a kerl-managed Erlang/OTP installation
No build named asdf_25.3.2.8
Downloading 25.3.2.8 to /Users/trevorbrown/.asdf/downloads/erlang/25.3.2.8...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 99.8M  100 99.8M    0     0  6805k      0  0:00:15  0:00:15 --:--:-- 6885k
Extracting source code
Building Erlang/OTP 25.3.2.8 (asdf_25.3.2.8), please wait...
APPLICATIONS DISABLED (See: /Users/trevorbrown/.asdf/plugins/erlang/kerl-home/builds/asdf_25.3.2.8/otp_build_25.3.2.8.log)
 * jinterface     : Java compiler disabled by user
 * odbc           : ODBC library - link check failed

DOCUMENTATION INFORMATION (See: /Users/trevorbrown/.asdf/plugins/erlang/kerl-home/builds/asdf_25.3.2.8/otp_build_25.3.2.8.log)
 * documentation  : 
 *                  fop is missing.
 *                  Using fakefop to generate placeholder PDF files.

Erlang/OTP 25.3.2.8 (asdf_25.3.2.8) has been successfully built
Cleaning up compilation products for asdf_25.3.2.8
Cleaned up compilation products for asdf_25.3.2.8 under /Users/trevorbrown/.asdf/plugins/erlang/kerl-home/builds

# Build directory for 25.3.2.8 is not persisted
$ ls ~/.asdf/plugins/erlang/kerl-home/builds
asdf_26.1.1 asdf_26.1.2 asdf_26.2   asdf_26.2.1
```