### PR TITLE
Remove duplicated libncurses-dev from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ If you want to install all the above:
 #### Debian 12 (bookworm)
 
 To install the whole dependency suite:
-`apt-get -y install build-essential autoconf m4 libncurses-dev libwxgtk3.2-dev libwxgtk-webview3.2-dev libgl1-mesa-dev libglu1-mesa-dev libpng-dev libssh-dev unixodbc-dev xsltproc fop libxml2-utils libncurses-dev openjdk-17-jdk`
+`apt-get -y install build-essential autoconf m4 libncurses-dev libwxgtk3.2-dev libwxgtk-webview3.2-dev libgl1-mesa-dev libglu1-mesa-dev libpng-dev libssh-dev unixodbc-dev xsltproc fop libxml2-utils openjdk-17-jdk`
 
 ### Arch Linux
 


### PR DESCRIPTION
I removed the duplicated `libncurses-dev` entry from the README.md in the Debian installation guide.