### PR TITLE
Add install step to fix compat between kerl & recent ubuntu versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ If you want to install all the above:
 `apt-get -y install build-essential autoconf m4 libncurses5-dev libwxgtk3.0-gtk3-dev libwxgtk-webview3.0-gtk3-dev libgl1-mesa-dev libglu1-mesa-dev libpng-dev libssh-dev unixodbc-dev xsltproc fop libxml2-utils libncurses-dev openjdk-11-jdk`
 
 #### Ubuntu 24.04 LTS
+
+Ubuntu versions 23.0+ have broken compatibility with `kerl`, which `asdf-erlang` depends upon. When installing this plugin, specify `kerl` version 4.1.1, where this issue has been fixed:  
+`ASDF_KERL_VERSION='4.1.1' asdf plugin add erlang https://github.com/asdf-vm/asdf-erlang.git`
+
+`libncurses5-dev`, a dependency of this plugin. This issue is fixed in a recent update to `kerl`, you can install the updated version with 
+
 If you want to install all the above:
 `apt-get -y install build-essential autoconf m4 libncurses5-dev libwxgtk3.2-dev libwxgtk-webview3.2-dev libgl1-mesa-dev libglu1-mesa-dev libpng-dev libssh-dev unixodbc-dev xsltproc fop libxml2-utils libncurses-dev openjdk-11-jdk`
 


### PR DESCRIPTION
Fixes #290 

Ubuntu compatibility Issue was fixed in [`kerl` PR #521](https://github.com/kerl/kerl/pull/521), this PR documents that fix in the Ubuntu 24.04 LTS install instructions.

Alternatively, the default kerl version could be updated from 4.0.0 to 4.1.1 which would almost entirely remove the need for this documentation change. That would leave the compatibility issue documented only in GH issues as it is currently. New installs would avoid the issue by default, simply by following the existing install instructions.