### PR TITLE
Update default kerl version to 4.1.1

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -1,4 +1,4 @@
-export KERL_VERSION="${ASDF_KERL_VERSION:-4.0.0}"
+export KERL_VERSION="${ASDF_KERL_VERSION:-4.1.1}"
 
 handle_failure() {
     function=$1


### PR DESCRIPTION
#290 

Version 4.1.1 fixes compatibility with Ubuntu versions >=23.0

This could alternatively be addressed only in documentation, as I offer in #313 