### PR TITLE
Update Fedora wx package names

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Needed for terminal handling
 `sudo yum install -y ncurses-devel`
 
 For building with wxWidgets (start observer or debugger!). Note that you may need to select the right `wx-config` before installing Erlang.
-`sudo yum install -y wxGTK3-devel wxBase3`
+`sudo yum install -y wxGTK-devel wxBase`
 
 For building ssl
 `sudo yum install -y openssl-devel`


### PR DESCRIPTION
Fixes #321 

At some point, the wx* packages for Fedora dropped their "3"s; they've been 3-less at least since Fedora 39 (current is Fedora 41).

Packages:
- https://packages.fedoraproject.org/pkgs/wxGTK/wxBase/
- https://packages.fedoraproject.org/pkgs/wxGTK/wxGTK-devel/