### PR TITLE
Update Fedora build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,10 +172,7 @@ These steps assume a most recent build of CentOS (currently
 tested on CentOS 7.5 x64 & Fedora 28 x64)
 
 Install the build tools
-`sudo yum groupinstall -y 'Development Tools' 'C Development Tools and Libraries'`
-
-Automatic configure script builder
-`sudo yum install -y autoconf`
+`sudo yum install -y git gcc g++ auto make autoconf`
 
 Needed for terminal handling
 `sudo yum install -y ncurses-devel`

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ These steps assume a most recent build of CentOS (currently
 tested on CentOS 7.5 x64 & Fedora 28 x64)
 
 Install the build tools
-`sudo yum install -y git gcc g++ auto make autoconf`
+`sudo yum install -y git gcc g++ automake autoconf`
 
 Needed for terminal handling
 `sudo yum install -y ncurses-devel`


### PR DESCRIPTION
As pointed out in #321, the groupinstall command doesn't exist anymore.
```
⬢ [fedora-41] ❯ sudo yum groupinstall -y 'Development Tools' 'C Development Tools and Libraries'
Unknown argument "groupinstall" for command "dnf5". Add "--help" for more information about the arguments.
It could be a command provided by a plugin, try: dnf5 install 'dnf5-command(groupinstall)'
```
I've personally always skipped installing these whole groups anyway in favor of individual packages.