### PR TITLE
Set `CI=true`

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -1,3 +1,6 @@
+#!/bin/sh
+
+export CI='true'
 export KERL_VERSION="${ASDF_KERL_VERSION:-4.3.0}"
 
 handle_failure() {
@@ -33,10 +36,12 @@ download_kerl() {
     # Print to stderr so asdf doesn't assume this string is a list of versions
     printf "Downloading kerl...\\n" >&2
 
-    local kerl_url="https://raw.githubusercontent.com/kerl/kerl/${KERL_VERSION}/kerl"
+    kerl_url="https://raw.githubusercontent.com/kerl/kerl/${KERL_VERSION}/kerl"
 
     curl -Lo "$(kerl_path)" "$kerl_url"
     chmod +x "$(kerl_path)"
+
+    unset kerl_url
 }
 
 kerl_path() {
@@ -44,13 +49,13 @@ kerl_path() {
 }
 
 set_kerl_env() {
-    local kerl_home
     kerl_home="$(dirname "$(dirname "$0")")/kerl-home"
     mkdir -p "$kerl_home"
     export KERL_BASE_DIR="$kerl_home"
     export KERL_BUILD_BACKEND="git"
     export KERL_CONFIG="$kerl_home/.kerlrc"
     export KERL_DOWNLOAD_DIR="${ASDF_DOWNLOAD_PATH:-}"
+    unset kerl_home
 }
 
 update_available_versions() {

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -1,5 +1,18 @@
 #!/bin/sh
 
+# By setting CI=true, this means that `kerl version` will not echo the
+# following output if `tput sgr0` fails within the `kerl` script:
+#
+# "Colorization disabled as 'tput' (via 'ncurses') seems to be
+#  unavailable."
+#
+# `tput sgr0` can fail if `kerl` is run via `asdf`, for instance.
+#
+# This is important, because the version check in this script depends on
+# the output simply being a version string, like `4.3.0`. If the above
+# text is output, the version check fails in ensure_kerl_installed, and
+# kerl is _always_ downloaded.
+#
 export CI='true'
 export KERL_VERSION="${ASDF_KERL_VERSION:-4.3.0}"
 


### PR DESCRIPTION
This prevents the following output when `asdf uninstall...` is run:

```
Colorization disabled as tput (via ncurses) seems to be unavailable.
```

In addition, remove use of `local` since it is not POSIX `sh`, and add shebang so shellcheck can apply rules.