### PR TITLE
docs: remove unused libncurses5-dev on Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Install system packages on Ubuntu
         if: ${{ runner.os == 'Linux' }}
-        run: sudo apt-get update; sudo apt-get -y install build-essential autoconf m4 libncurses5-dev libwxgtk3.2-dev libgl1-mesa-dev libglu1-mesa-dev libpng-dev libssh-dev xsltproc fop libxml2-utils libncurses-dev
+        run: sudo apt-get update; sudo apt-get -y install build-essential autoconf m4 libwxgtk3.2-dev libgl1-mesa-dev libglu1-mesa-dev libpng-dev libssh-dev xsltproc fop libxml2-utils libncurses-dev
 
       - name: Install system packages on macOS
         if: ${{ runner.os == 'macOS' }}

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ If you want to install all the above:
 
 #### Ubuntu 24.04 LTS
 If you want to install all the above:
-`apt-get -y install build-essential autoconf m4 libncurses5-dev libwxgtk3.2-dev libwxgtk-webview3.2-dev libgl1-mesa-dev libglu1-mesa-dev libpng-dev libssh-dev unixodbc-dev xsltproc fop libxml2-utils libncurses-dev openjdk-11-jdk`
+`apt-get -y install build-essential autoconf m4 libwxgtk3.2-dev libwxgtk-webview3.2-dev libgl1-mesa-dev libglu1-mesa-dev libpng-dev libssh-dev unixodbc-dev xsltproc fop libxml2-utils libncurses-dev openjdk-11-jdk`
 
 #### Debian 12 (bookworm)
 


### PR DESCRIPTION
On Ubuntu 24.04 installation informs about omitting this package in favor of already present in list `libncurses-dev`.

Info from command `apt install libncurses5-dev`:
`Note, selecting 'libncurses-dev' instead of 'libncurses5-dev'`